### PR TITLE
Add output folder option for shipping builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@ nunit-*.xml
 
 # Build Results of an ATL Project
 [Dd]ebugPS/
-[Rr]eleasePS/
 dlldata.c
 
 # Benchmark Results

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ x86/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/
+[Rr]elease/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
@@ -47,6 +48,7 @@ nunit-*.xml
 
 # Build Results of an ATL Project
 [Dd]ebugPS/
+[Rr]eleasePS/
 dlldata.c
 
 # Benchmark Results

--- a/EditorApp/CMakeLists.txt
+++ b/EditorApp/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(${PROJECT_NAME} ${SOURCES})
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE GUI)
 target_compile_definitions(${PROJECT_NAME} PRIVATE SGE_EDITOR)
+target_compile_definitions(${PROJECT_NAME} PRIVATE SGE_SOLUTION_DIR="${CMAKE_BINARY_DIR}")
 
 target_include_directories(${PROJECT_NAME} PRIVATE 
 	${CMAKE_SOURCE_DIR}/Engine/include

--- a/EditorApp/Editor.cpp
+++ b/EditorApp/Editor.cpp
@@ -2913,14 +2913,19 @@ class GUI_Helper : public GuiMenu {
 						// Path to the Python script
 						std::string pythonScriptPath = "../../scripts/build_shipping.py";
 
-						// Command to execute the Python script with folderPath as an argument
-						std::string command = "python \"" + pythonScriptPath + "\" \"" + Engine::get()->getInitParams().projectDir + "\"";
+                                                // Determine asset, output, and solution paths
+                                                std::string assetsFolder = Engine::get()->getInitParams().projectDir;
+                                                std::string outputFolder = std::string(SGE_SOLUTION_DIR) + "/../Release";
+                                                std::string solutionDir = std::string(SGE_SOLUTION_DIR);
 
-						// Run the command
-						std::system(command.c_str());
+                                                // Command to execute the Python script with project, output, and solution paths
+                                                std::string command = "python \"" + pythonScriptPath + "\" \"" + assetsFolder + "\" \"" + outputFolder + "\" \"" + solutionDir + "\"";
 
-						//std::filesystem::create_directories("../Game/data");
-					}
+                                                // Run the command
+                                                std::system(command.c_str());
+
+                                                //std::filesystem::create_directories("../Game/data");
+                                        }
 					if (ImGui::MenuItem("Reload config", "")) {
 						Engine::get()->reloadEngineConfig();
 					}

--- a/Game/CMakeLists.txt
+++ b/Game/CMakeLists.txt
@@ -8,9 +8,10 @@ add_executable(${PROJECT_NAME} ${SOURCES})
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE SGE_SHIPPING)
 
-target_include_directories(${PROJECT_NAME} PRIVATE 
-	${CMAKE_SOURCE_DIR}/Engine/src
-	${CMAKE_SOURCE_DIR}/NativeScripts
+target_include_directories(${PROJECT_NAME} PRIVATE
+        ${CMAKE_SOURCE_DIR}/Engine/src
+        ${CMAKE_SOURCE_DIR}/Engine/include
+        ${CMAKE_SOURCE_DIR}/NativeScripts
 )
 
 target_link_directories(${PROJECT_NAME} PRIVATE

--- a/scripts/build_shipping.py
+++ b/scripts/build_shipping.py
@@ -45,8 +45,7 @@ def main():
     copy_folder(folder_to_game, assets_dest)
 
     # Step 3: Copy only DLLs and the executable from bin/Release next to the executable
-    root_dir = os.path.abspath(os.path.join(solution_dir, ".."))
-    bin_release_src = os.path.join(root_dir, "bin", "Release")
+    bin_release_src = os.path.join(solution_dir, "bin", "Release")
     if os.path.isdir(bin_release_src):
         for item in os.listdir(bin_release_src):
             src_path = os.path.join(bin_release_src, item)

--- a/scripts/build_shipping.py
+++ b/scripts/build_shipping.py
@@ -3,47 +3,19 @@ import shutil
 import sys
 import subprocess
 
-def copy_folder_contents(folder_to_game, output_folder):
-    """
-    Copies all contents from folder_to_game to output_folder.
-    Creates the output_folder if it does not exist.
-    """
-    # Ensure output_folder exists, create it if necessary
-    if not os.path.exists(output_folder):
-        os.makedirs(output_folder)
-        print(f"Created output folder: {output_folder}")
 
-    # Copy all contents from folder_to_game to output_folder
-    try:
-        # Iterate through all files and subfolders in folder_to_game
-        for item in os.listdir(folder_to_game):
-            src_path = os.path.join(folder_to_game, item)
-            dest_path = os.path.join(output_folder, item)
-
-            # Check if the item is a file or directory
-            if os.path.isdir(src_path):
-                # Recursively copy directories
-                shutil.copytree(src_path, dest_path)
-            else:
-                # Copy files
-                shutil.copy2(src_path, dest_path)
-
-        print(f"All contents copied from {folder_to_game} to {output_folder}")
-    except Exception as e:
-        print(f"Error while copying: {e}")
+def copy_folder(src, dest):
+    """Copy an entire folder to *dest* overwriting existing content."""
+    if os.path.exists(dest):
+        shutil.rmtree(dest)
+    shutil.copytree(src, dest)
+    print(f"Copied {src} -> {dest}")
 
 
-def build_project(msbuild_path, project_path, folder_to_game):
-    """
-    Builds the project using MSBuild and defines the GAME_FOLDER preprocessor macro.
-    """
-    build_command = [
-        msbuild_path, project_path, "/p:Configuration=Release"
-    ]
-
-    # Print the build command for debugging purposes
+def build_project(msbuild_path, project_path):
+    """Build the project using MSBuild."""
+    build_command = [msbuild_path, project_path, "/p:Configuration=Release"]
     print(f"Executing: {' '.join(build_command)}")
-
     try:
         subprocess.check_call(build_command)
         print("Build successful!")
@@ -52,21 +24,37 @@ def build_project(msbuild_path, project_path, folder_to_game):
         sys.exit(1)
 
 
-# Ensure the script receives a folder_to_game argument
-if len(sys.argv) < 2:
-    print("Error: folder_to_game path not provided.")
-    sys.exit(1)
+def main():
+    if len(sys.argv) < 4:
+        print("Error: folder_to_game, output_folder, and solution_dir paths not provided.")
+        sys.exit(1)
 
-# Capture folder_to_game from the arguments
-folder_to_game = sys.argv[1]
-output_folder = os.path.join(os.getcwd(), "../Release/data")
+    folder_to_game = sys.argv[1]
+    output_folder = sys.argv[2]
+    solution_dir = sys.argv[3]
 
-# Define the MSBuild path and project path
-msbuild_path = r"C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"
-project_path = r"../Game/Game.vcxproj"
+    msbuild_path = r"C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"
+    project_path = os.path.join(solution_dir, "Game", "Game.vcxproj")
 
-# Step 1: Build the project
-build_project(msbuild_path, project_path, folder_to_game)
+    # Step 1: Build the project
+    build_project(msbuild_path, project_path)
 
-# Step 2: Copy the contents after build
-copy_folder_contents(folder_to_game, output_folder)
+    # Step 2: Copy the asset folder into output/data
+    os.makedirs(output_folder, exist_ok=True)
+    assets_dest = os.path.join(output_folder, "data")
+    copy_folder(folder_to_game, assets_dest)
+
+    # Step 3: Copy only DLLs and the executable from bin/Release next to the executable
+    root_dir = os.path.abspath(os.path.join(solution_dir, ".."))
+    bin_release_src = os.path.join(root_dir, "bin", "Release")
+    if os.path.isdir(bin_release_src):
+        for item in os.listdir(bin_release_src):
+            src_path = os.path.join(bin_release_src, item)
+            if os.path.isfile(src_path) and os.path.splitext(item)[1].lower() in (".dll", ".exe"):
+                shutil.copy2(src_path, output_folder)
+        print(f"Copied DLLs and executables from {bin_release_src} -> {output_folder}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- allow specifying an output and solution directory in `build_shipping.py` and copy assets into it
- copy only DLL and EXE files from `bin/Release` alongside the built executable
- update Editor build command to forward project, output, and solution paths
- define `SGE_SOLUTION_DIR` in the Editor CMake config and use it to provide the correct solution path

## Testing
- `python -m py_compile scripts/build_shipping.py`


------
https://chatgpt.com/codex/tasks/task_e_689760bcd320832a91e813ab426d7eab