### PR TITLE
Keep entity popup open until confirmation

### DIFF
--- a/EditorApp/Editor.cpp
+++ b/EditorApp/Editor.cpp
@@ -685,7 +685,10 @@ void displayentityName(const Entity& e)
 {
 	auto& obj = e.getComponent<ObjectComponent>();
 
-	ImGui::Selectable(obj.name.c_str(), (selectedEntity == e));
+        // Prevent popups from closing when selecting an entity.
+        // This allows selection dialogs (e.g., choosing terrain for foliage)
+        // to remain open until the user confirms or cancels.
+        ImGui::Selectable(obj.name.c_str(), (selectedEntity == e), ImGuiSelectableFlags_DontClosePopups);
 
 	if (ImGui::IsItemClicked())
 	{


### PR DESCRIPTION
## Summary
- avoid closing entity selection popups on item click

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_689837ddcfb8832a8f211ec3e11a8369