### PR TITLE
Add window resize support

### DIFF
--- a/Engine/src/Engine.cpp
+++ b/Engine/src/Engine.cpp
@@ -470,6 +470,19 @@ void Engine::handleEvents(SDL_Event& e, bool& quit)
             quit = true;
         }
 
+        if (e.type == SDL_WINDOWEVENT && e.window.event == SDL_WINDOWEVENT_RESIZED)
+        {
+            m_window->resize(e.window.data1, e.window.data2);
+            if (m_context)
+            {
+                auto activeScene = m_context->getActiveScene();
+                if (activeScene)
+                {
+                    activeScene->onWindowResize(e.window.data1, e.window.data2);
+                }
+            }
+        }
+
 
         m_eventSystem->dispatch(e);
     }

--- a/Engine/src/Scene.cpp
+++ b/Engine/src/Scene.cpp
@@ -106,6 +106,47 @@ void Scene::setPrimaryCamera(Entity e)
 //	m_activeCamera = camera;
 //}
 
+void Scene::onWindowResize(int width, int height)
+{
+        float aspect = static_cast<float>(width) / static_cast<float>(height);
+
+        auto camView = m_registry->get().view<CameraComponent>();
+        for (auto [entity, cam] : camView.each())
+        {
+                cam.aspect = aspect;
+        }
+
+        if (m_primaryCamera.valid() && m_primaryCamera.HasComponent<CameraComponent>())
+        {
+                auto& cam = m_primaryCamera.getComponent<CameraComponent>();
+                m_defaultPerspectiveProjection = glm::perspective(cam.fovy, aspect, cam.znear, cam.zfar);
+        }
+        else
+        {
+                m_defaultPerspectiveProjection = glm::perspective(45.0f, aspect, 0.1f, 1000.0f);
+        }
+
+        m_renderTargetTexture = Texture::createEmptyTexture(width, height);
+        m_renderTargetRBO = std::make_shared<RenderBufferObject>(width, height);
+
+        m_renderTargetFBO->bind();
+        m_renderTargetFBO->attachTexture(m_renderTargetTexture.get()->getID(), GL_COLOR_ATTACHMENT0);
+        unsigned int attachments[1] = { GL_COLOR_ATTACHMENT0 };
+        glDrawBuffers(1, attachments);
+        m_renderTargetFBO->attachRenderBuffer(m_renderTargetRBO->GetID(), FrameBufferObject::AttachmentType::Depth_Stencil);
+        m_renderTargetFBO->unbind();
+
+        m_deferredRenderer = std::make_shared<DeferredRenderer>(m_renderTargetFBO, this);
+        m_deferredRenderer->init();
+        m_forwardRenderer = std::make_shared<Renderer>(m_renderTargetFBO, this);
+        m_forwardRenderer->init();
+
+        if (m_postProcessProjector)
+        {
+                m_postProcessProjector->init(width, height);
+        }
+}
+
 void Scene::init(Context* context)
 {
 	m_context = context;

--- a/Engine/src/Scene.h
+++ b/Engine/src/Scene.h
@@ -104,12 +104,14 @@ public:
 
 	glm::mat4 getProjection() const;
 
-	Entity getActiveCamera() const;
-	void setPrimaryCamera(Entity e);
+        Entity getActiveCamera() const;
+        void setPrimaryCamera(Entity e);
 
-	void startSimulation();
-	void stopSimulation();
-	bool isSimulationActive() const;
+        void onWindowResize(int width, int height);
+
+        void startSimulation();
+        void stopSimulation();
+        bool isSimulationActive() const;
 
 	Entity getEntityByName(const std::string& name) const;
 

--- a/Engine/src/Window.cpp
+++ b/Engine/src/Window.cpp
@@ -32,7 +32,7 @@ int Window::init()
 	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 
 
-	SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_SHOWN);
+        SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
 
 	m_width = SCREEN_WIDTH;
 	m_height = SCREEN_HEIGHT;
@@ -116,9 +116,18 @@ inline void Window::SwapBuffer()
 }
 
 void Window::update()
-{ 
-	if (m_isMouseLocked)
-		SDL_WarpMouseInWindow(m_mainWindow, m_halfWidth, m_halfHeight); 
+{
+        if (m_isMouseLocked)
+                SDL_WarpMouseInWindow(m_mainWindow, m_halfWidth, m_halfHeight);
+}
+
+void Window::resize(int width, int height)
+{
+        m_width = width;
+        m_height = height;
+        m_halfWidth = m_width / 2.f;
+        m_halfHeight = m_height / 2.f;
+        glViewport(0, 0, width, height);
 }
 
 void* Window::GetNativeWindow()

--- a/Engine/src/Window.h
+++ b/Engine/src/Window.h
@@ -17,14 +17,15 @@ public:
 	int init();
 
 	inline int getWidth() { return m_width; }
-	inline int getHeight() { return m_height; }
+        inline int getHeight() { return m_height; }
 
-	void close();
+        void close();
 
-	void SwapBuffer();
-	void update();
-	void lockMouse() { m_isMouseLocked = true; }
-	void unlockMouse() { m_isMouseLocked = false; }
+        void SwapBuffer();
+        void update();
+        void resize(int width, int height);
+        void lockMouse() { m_isMouseLocked = true; }
+        void unlockMouse() { m_isMouseLocked = false; }
 
 	SDL_Window* GetWindow() { return m_mainWindow; }
 	SDL_GLContext GetContext() { return m_glContext; }


### PR DESCRIPTION
## Summary
- allow SDL window to be resizable and track size changes
- handle SDL resize events to update window dimensions and scene data
- rebuild scene projections and buffers on resize

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: cc: error: /MT: linker input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68987ddafe74832aa8d6978391efda90