### PR TITLE
Add window resize handling

### DIFF
--- a/Engine/src/core/Engine.cpp
+++ b/Engine/src/core/Engine.cpp
@@ -522,6 +522,16 @@ void Engine::handleEvents(bool& quit)
 
         m_imguiHandler->proccessEvents(e);
 
+        if (e.type == SDL_WINDOWEVENT &&
+            (e.window.event == SDL_WINDOWEVENT_RESIZED || e.window.event == SDL_WINDOWEVENT_SIZE_CHANGED))
+        {
+            m_window->resize(e.window.data1, e.window.data2);
+            if (m_context && m_context->getActiveScene())
+            {
+                m_context->getActiveScene()->onWindowResize(e.window.data1, e.window.data2);
+            }
+        }
+
         //User requests quit
         if (e.type == SDL_QUIT)
         {

--- a/Engine/src/core/Window.cpp
+++ b/Engine/src/core/Window.cpp
@@ -37,7 +37,7 @@ int Window::init()
 	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 
 
-	SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_SHOWN);
+        SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
 
 	m_width = SCREEN_WIDTH;
 	m_height = SCREEN_HEIGHT;

--- a/Engine/src/core/Window.cpp
+++ b/Engine/src/core/Window.cpp
@@ -99,9 +99,17 @@ int Window::init()
 	m_halfWidth = m_width / 2.f;
 	m_halfHeight = m_height / 2.f;
 		
-	logInfo("SDL has initialized successfully.");
+        logInfo("SDL has initialized successfully.");
 
-	return true;
+        return true;
+}
+
+void Window::resize(int width, int height)
+{
+        m_width = width;
+        m_height = height;
+        m_halfWidth = m_width / 2.f;
+        m_halfHeight = m_height / 2.f;
 }
 
 void Window::close()

--- a/Engine/src/core/Window.h
+++ b/Engine/src/core/Window.h
@@ -14,10 +14,12 @@ public:
 
 	Window();
 
-	int init();
+        int init();
 
-	inline int getWidth() { return m_width; }
-	inline int getHeight() { return m_height; }
+        inline int getWidth() { return m_width; }
+        inline int getHeight() { return m_height; }
+
+        void resize(int width, int height);
 
 	void close();
 

--- a/Engine/src/render/DeferredRenderer.cpp
+++ b/Engine/src/render/DeferredRenderer.cpp
@@ -191,7 +191,7 @@ void DeferredRenderer::render()
 
     if (graphics->material)
     {
-        graphics->material->use(graphics->shader);
+	graphics->material->use(graphics->shader);
     }
 
 	// Draw
@@ -402,4 +402,45 @@ void DeferredRenderer::renderScene(Scene* scene)
 const FrameBufferObject& DeferredRenderer::getGBuffer() const
 {
 	return m_gBuffer;
+}
+
+void DeferredRenderer::resize(int w, int h)
+{
+	m_renderBuffer = RenderBufferObject(w, h);
+
+	m_gBuffer.bind();
+
+	m_positionTexture = Texture::createEmptyTexture(w, h, GL_RGBA16F, GL_RGBA, GL_FLOAT);
+	m_gBuffer.attachTexture(m_positionTexture.get()->getID(), GL_COLOR_ATTACHMENT0);
+
+	m_normalTexture = Texture::createEmptyTexture(w, h, GL_RGBA16F, GL_RGBA, GL_FLOAT);
+	m_gBuffer.attachTexture(m_normalTexture.get()->getID(), GL_COLOR_ATTACHMENT1);
+
+	m_albedoTexture = Texture::createEmptyTexture(w, h, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE);
+	m_gBuffer.attachTexture(m_albedoTexture.get()->getID(), GL_COLOR_ATTACHMENT2);
+
+	m_MRATexture = Texture::createEmptyTexture(w, h, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE);
+	m_gBuffer.attachTexture(m_MRATexture.get()->getID(), GL_COLOR_ATTACHMENT3);
+
+	unsigned int attachments[4] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT2, GL_COLOR_ATTACHMENT3 };
+	glDrawBuffers(4, attachments);
+
+	m_gBuffer.attachRenderBuffer(m_renderBuffer.GetID(), FrameBufferObject::AttachmentType::Depth_Stencil);
+	m_gBuffer.unbind();
+
+	m_ssaoRenderBuffer = RenderBufferObject(w, h);
+	m_ssaoFBO.bind();
+	m_ssaoColorBuffer = Texture::createEmptyTexture(w, h, GL_RED, GL_RED, GL_FLOAT);
+	m_ssaoFBO.attachTexture(m_ssaoColorBuffer.get()->getID(), GL_COLOR_ATTACHMENT0);
+	unsigned int ssaoAttachments[1] = { GL_COLOR_ATTACHMENT0 };
+	glDrawBuffers(1, ssaoAttachments);
+	m_ssaoFBO.attachRenderBuffer(m_ssaoRenderBuffer.GetID(), FrameBufferObject::AttachmentType::Depth_Stencil);
+	m_ssaoFBO.unbind();
+
+	m_ssaoBlurRenderBuffer = RenderBufferObject(w, h);
+	m_ssaoBlurFBO.bind();
+	m_ssaoBlurColorBuffer = Texture::createEmptyTexture(w, h, GL_RED, GL_RED, GL_FLOAT);
+	m_ssaoBlurFBO.attachTexture(m_ssaoBlurColorBuffer.get()->getID(), GL_COLOR_ATTACHMENT0);
+	m_ssaoBlurFBO.attachRenderBuffer(m_ssaoBlurRenderBuffer.GetID(), FrameBufferObject::AttachmentType::Depth_Stencil);
+	m_ssaoBlurFBO.unbind();
 }

--- a/Engine/src/render/DeferredRenderer.h
+++ b/Engine/src/render/DeferredRenderer.h
@@ -23,6 +23,8 @@ public:
 	void renderSceneUsingCustomShader(Scene* scene);
 	void setUniforms(Shader* shader);
 
+	void resize(int w, int h);
+
 	const FrameBufferObject& getGBuffer() const;
 
 private:

--- a/Engine/src/render/RenderCommand.cpp
+++ b/Engine/src/render/RenderCommand.cpp
@@ -1,6 +1,7 @@
 #include "render/RenderCommand.h"
 #include "core/Engine.h"
 #include "core/System.h"
+#include "core/Window.h"
 #include "render/Graphics.h"
 #include "render/RenderView.h"
 #include "render/VertexArrayObject.h"
@@ -56,7 +57,7 @@ void RenderCommand::setViewport(int x, int y, int w, int h)
 
 void RenderCommand::copyFrameBufferData(unsigned int src, unsigned int dst, int bufferBit)
 {
-	auto graphics = Engine::get()->getSubSystem<Graphics>();
+        auto graphics = Engine::get()->getSubSystem<Graphics>();
 
 	// Bind G-Buffer as src
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, src);
@@ -64,19 +65,34 @@ void RenderCommand::copyFrameBufferData(unsigned int src, unsigned int dst, int 
 	// Bind default buffer as dest
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, dst);
 
-	auto renderView = graphics->renderView;
+        auto renderView = graphics->renderView;
 
-	assert(renderView);
+        assert(renderView);
 
-	auto& viewport = renderView->getViewport();
+        auto& viewport = renderView->getViewport();
 
-	// Copy src to dest
-	glBlitFramebuffer(0, 0, viewport.w, viewport.h,
-		0, 0, viewport.w, viewport.h,
-		bufferBit, GL_NEAREST);
+        int destW = viewport.w;
+        int destH = viewport.h;
+
+        // If copying to the default framebuffer, use the window dimensions as
+        // the destination size to ensure the final image covers the window.
+        if (dst == 0)
+        {
+                auto window = Engine::get()->getWindow();
+                if (window)
+                {
+                        destW = window->getWidth();
+                        destH = window->getHeight();
+                }
+        }
+
+        // Copy src to dest
+        glBlitFramebuffer(0, 0, viewport.w, viewport.h,
+                0, 0, destW, destH,
+                bufferBit, GL_NEAREST);
 
 
-	glBindFramebuffer(GL_FRAMEBUFFER, dst);
+        glBindFramebuffer(GL_FRAMEBUFFER, dst);
 }
 
 //void RenderCommand::drawIndexed(const VertexArrayObject* vao)

--- a/Engine/src/render/RenderCommand.cpp
+++ b/Engine/src/render/RenderCommand.cpp
@@ -57,7 +57,7 @@ void RenderCommand::setViewport(int x, int y, int w, int h)
 
 void RenderCommand::copyFrameBufferData(unsigned int src, unsigned int dst, int bufferBit)
 {
-        auto graphics = Engine::get()->getSubSystem<Graphics>();
+    auto graphics = Engine::get()->getSubSystem<Graphics>();
 
 	// Bind G-Buffer as src
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, src);
@@ -65,34 +65,34 @@ void RenderCommand::copyFrameBufferData(unsigned int src, unsigned int dst, int 
 	// Bind default buffer as dest
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, dst);
 
-        auto renderView = graphics->renderView;
+    auto renderView = graphics->renderView;
 
-        assert(renderView);
+    assert(renderView);
 
-        auto& viewport = renderView->getViewport();
+    auto& viewport = renderView->getViewport();
 
-        int destW = viewport.w;
-        int destH = viewport.h;
+    int destW = viewport.w;
+    int destH = viewport.h;
 
-        // If copying to the default framebuffer, use the window dimensions as
-        // the destination size to ensure the final image covers the window.
-        if (dst == 0)
+    // If copying to the default framebuffer, use the window dimensions as
+    // the destination size to ensure the final image covers the window.
+    if (dst == 0)
+    {
+        auto window = Engine::get()->getWindow();
+        if (window)
         {
-                auto window = Engine::get()->getWindow();
-                if (window)
-                {
-                        destW = window->getWidth();
-                        destH = window->getHeight();
-                }
+            destW = window->getWidth();
+            destH = window->getHeight();
         }
+    }
 
-        // Copy src to dest
-        glBlitFramebuffer(0, 0, viewport.w, viewport.h,
-                0, 0, destW, destH,
-                bufferBit, GL_NEAREST);
+    // Copy src to dest
+    glBlitFramebuffer(0, 0, viewport.w, viewport.h,
+            0, 0, destW, destH,
+            bufferBit, GL_NEAREST);
 
 
-        glBindFramebuffer(GL_FRAMEBUFFER, dst);
+    glBindFramebuffer(GL_FRAMEBUFFER, dst);
 }
 
 //void RenderCommand::drawIndexed(const VertexArrayObject* vao)

--- a/Engine/src/render/RenderView.cpp
+++ b/Engine/src/render/RenderView.cpp
@@ -71,10 +71,10 @@ void RenderView::setTexture(Resource<Texture> texture)
 
 void RenderView::resize(int w, int h)
 {
-        m_viewport.w = w;
-        m_viewport.h = h;
-        renderTargets[0] = RenderTarget(m_viewport);
-        renderTargets[1] = RenderTarget(m_viewport);
+    m_viewport.w = w;
+    m_viewport.h = h;
+    renderTargets[0] = RenderTarget(m_viewport);
+    renderTargets[1] = RenderTarget(m_viewport);
 }
 
 void RenderView::bind()

--- a/Engine/src/render/RenderView.cpp
+++ b/Engine/src/render/RenderView.cpp
@@ -61,12 +61,20 @@ Resource<Texture> RenderView::getRenderTargetTexture() const
 
 unsigned int RenderView::getRenderTargetFrameBufferID() const
 {
-	return renderTargets[0].m_renderTargetFBO->getID();
+        return renderTargets[0].m_renderTargetFBO->getID();
 }
 
 void RenderView::setTexture(Resource<Texture> texture)
 {
-	renderTargets[0].m_renderTargetFBO->attachTexture(texture.get()->getID(), GL_COLOR_ATTACHMENT0);
+        renderTargets[0].m_renderTargetFBO->attachTexture(texture.get()->getID(), GL_COLOR_ATTACHMENT0);
+}
+
+void RenderView::resize(int w, int h)
+{
+        m_viewport.w = w;
+        m_viewport.h = h;
+        renderTargets[0] = RenderTarget(m_viewport);
+        renderTargets[1] = RenderTarget(m_viewport);
 }
 
 void RenderView::bind()

--- a/Engine/src/render/RenderView.h
+++ b/Engine/src/render/RenderView.h
@@ -39,12 +39,14 @@ public:
 	unsigned int getRenderTargetTextureID() const;
 	Resource<Texture> getRenderTargetTexture() const;
 
-	unsigned int getRenderTargetFrameBufferID() const;
+        unsigned int getRenderTargetFrameBufferID() const;
 
-	void setTexture(Resource<Texture> texture);
+        void setTexture(Resource<Texture> texture);
 
-	void bind();
-	void unbind();
+        void resize(int w, int h);
+
+        void bind();
+        void unbind();
 
 	void swapToAdditionalTarget();
 	void swapBackToMainTarget();

--- a/Engine/src/render/RenderView.h
+++ b/Engine/src/render/RenderView.h
@@ -39,14 +39,14 @@ public:
 	unsigned int getRenderTargetTextureID() const;
 	Resource<Texture> getRenderTargetTexture() const;
 
-        unsigned int getRenderTargetFrameBufferID() const;
+    unsigned int getRenderTargetFrameBufferID() const;
 
-        void setTexture(Resource<Texture> texture);
+    void setTexture(Resource<Texture> texture);
 
-        void resize(int w, int h);
+    void resize(int w, int h);
 
-        void bind();
-        void unbind();
+    void bind();
+    void unbind();
 
 	void swapToAdditionalTarget();
 	void swapBackToMainTarget();

--- a/Engine/src/render/VertexArrayObject.cpp
+++ b/Engine/src/render/VertexArrayObject.cpp
@@ -101,4 +101,5 @@ std::shared_ptr<VertexBufferObject> VertexArrayObject::getBufferByID(unsigned in
 			return buffer;
 		}
 	}
+	return nullptr;
 }

--- a/Engine/src/runtime/Scene.cpp
+++ b/Engine/src/runtime/Scene.cpp
@@ -38,6 +38,7 @@
 #include "utils/EquirectangularToCubemapConverter.h"
 #include "systems/CommonTextures.h"
 #include "render/RenderCommand.h"
+#include "glm/ext.hpp"
 #include "render/IBL.h"
 #include "core/Registry.h"
 #include "physics/Physics.h"
@@ -803,10 +804,37 @@ void Scene::removeEntity(const Entity& e)
 
 glm::mat4 Scene::getGameCameraView() const
 {
-	auto& primaryCamera = getGameCamera().getComponent<CameraComponent>();
-	auto& primaryCameraTransform = getGameCamera().getComponent<Transformation>();
+        auto& primaryCamera = getGameCamera().getComponent<CameraComponent>();
+        auto& primaryCameraTransform = getGameCamera().getComponent<Transformation>();
 
-	return glm::lookAt(primaryCameraTransform.getWorldPosition(), primaryCameraTransform.getWorldPosition() + primaryCamera.front, primaryCamera.up);
+        return glm::lookAt(primaryCameraTransform.getWorldPosition(), primaryCameraTransform.getWorldPosition() + primaryCamera.front, primaryCamera.up);
+}
+
+void Scene::onWindowResize(int w, int h)
+{
+        for (auto& [name, view] : m_renderViews)
+        {
+                view->resize(w, h);
+        }
+        if (m_highlightRenderView)
+        {
+                m_highlightRenderView->resize(w, h);
+        }
+
+        m_defaultPerspectiveProjection = glm::perspective(45.0f, (float)w / h, 0.1f, 1000.0f);
+        m_defaultUIProjection = glm::ortho(0.0f, (float)w, (float)h, 0.0f, -1.0f, 1.0f);
+
+        auto& reg = m_registry->getRegistry();
+        auto view = reg.view<CameraComponent>();
+        for (auto entity : view)
+        {
+                view.get<CameraComponent>(entity).aspect = (float)w / h;
+        }
+
+        if (m_postProcessProjector)
+        {
+                m_postProcessProjector->init(w, h);
+        }
 }
 
 

--- a/Engine/src/runtime/Scene.cpp
+++ b/Engine/src/runtime/Scene.cpp
@@ -812,34 +812,34 @@ glm::mat4 Scene::getGameCameraView() const
 
 void Scene::onWindowResize(int w, int h)
 {
-        for (auto& [name, view] : m_renderViews)
-        {
-                view->resize(w, h);
-        }
-       if (m_highlightRenderView)
-       {
-               m_highlightRenderView->resize(w, h);
-       }
+	for (auto& [name, view] : m_renderViews)
+	{
+		view->resize(w, h);
+	}
+	if (m_highlightRenderView)
+	{
+		m_highlightRenderView->resize(w, h);
+	}
 
-       if (m_deferredRenderer)
-       {
-               m_deferredRenderer->resize(w, h);
-       }
+	if (m_deferredRenderer)
+	{
+		m_deferredRenderer->resize(w, h);
+	}
 
-       m_defaultPerspectiveProjection = glm::perspective(45.0f, (float)w / h, 0.1f, 1000.0f);
-       m_defaultUIProjection = glm::ortho(0.0f, (float)w, (float)h, 0.0f, -1.0f, 1.0f);
+    m_defaultPerspectiveProjection = glm::perspective(45.0f, (float)w / h, 0.1f, 1000.0f);
+    m_defaultUIProjection = glm::ortho(0.0f, (float)w, (float)h, 0.0f, -1.0f, 1.0f);
 
-        auto& reg = m_registry->getRegistry();
-        auto view = reg.view<CameraComponent>();
-        for (auto entity : view)
-        {
-                view.get<CameraComponent>(entity).aspect = (float)w / h;
-        }
+    auto& reg = m_registry->getRegistry();
+    auto view = reg.view<CameraComponent>();
+	for (auto entity : view)
+	{
+		view.get<CameraComponent>(entity).aspect = (float)w / h;
+	}
 
-        if (m_postProcessProjector)
-        {
-                m_postProcessProjector->init(w, h);
-        }
+	if (m_postProcessProjector)
+	{
+		m_postProcessProjector->init(w, h);
+	}
 }
 
 

--- a/Engine/src/runtime/Scene.cpp
+++ b/Engine/src/runtime/Scene.cpp
@@ -816,13 +816,18 @@ void Scene::onWindowResize(int w, int h)
         {
                 view->resize(w, h);
         }
-        if (m_highlightRenderView)
-        {
-                m_highlightRenderView->resize(w, h);
-        }
+       if (m_highlightRenderView)
+       {
+               m_highlightRenderView->resize(w, h);
+       }
 
-        m_defaultPerspectiveProjection = glm::perspective(45.0f, (float)w / h, 0.1f, 1000.0f);
-        m_defaultUIProjection = glm::ortho(0.0f, (float)w, (float)h, 0.0f, -1.0f, 1.0f);
+       if (m_deferredRenderer)
+       {
+               m_deferredRenderer->resize(w, h);
+       }
+
+       m_defaultPerspectiveProjection = glm::perspective(45.0f, (float)w / h, 0.1f, 1000.0f);
+       m_defaultUIProjection = glm::ortho(0.0f, (float)w, (float)h, 0.0f, -1.0f, 1.0f);
 
         auto& reg = m_registry->getRegistry();
         auto view = reg.view<CameraComponent>();

--- a/Engine/src/runtime/Scene.h
+++ b/Engine/src/runtime/Scene.h
@@ -118,12 +118,14 @@ public:
 	unsigned int getRenderViewTextureID(const std::string& name) const;
 
 	unsigned int getGameRenderViewTextureID() const;
-	unsigned int getGameRenderViewFrameBufferID() const;
+        unsigned int getGameRenderViewFrameBufferID() const;
 
-	Entity getGameCamera() const;
-	void setGameCamera(Entity e);
+        Entity getGameCamera() const;
+        void setGameCamera(Entity e);
 
-	glm::mat4 getGameCameraView() const;
+        glm::mat4 getGameCameraView() const;
+
+        void onWindowResize(int w, int h);
 
 private:
 	// -------------------- Methods -------------------- //


### PR DESCRIPTION
## Summary
- support resizing SDL window and update internal dimensions
- propagate SDL resize events to scenes and render views for rebuilt buffers
- adjust camera aspect and default projections on window size changes

## Testing
- `cmake -S . -B build`
- `cmake --build build --target Engine` *(fails: cc: warning: /MT: linker input file unused because linking not done)*


------
https://chatgpt.com/codex/tasks/task_e_689881c8f2bc832ab3c9ee280951b5c4