### PR TITLE
Add dockable console window with logger callback

### DIFF
--- a/EditorApp/Editor.cpp
+++ b/EditorApp/Editor.cpp
@@ -64,15 +64,28 @@ static std::vector<std::string> g_consoleLog;
 static std::mutex g_consoleMutex;
 static bool g_scrollConsole = false;
 
+static void appendConsoleLog(const std::string& msg)
+{
+	std::lock_guard<std::mutex> lock(g_consoleMutex);
+	g_consoleLog.push_back(msg);
+	g_scrollConsole = true;
+}
+
+class ConsoleLoggerRegister
+{
+public:
+	ConsoleLoggerRegister()
+	{
+		Logger::setCallback(appendConsoleLog);
+	}
+};
+
+static ConsoleLoggerRegister clr;
+
 static std::string selectedTextureName;
 static bool showTextureDisplayWindow = false;
 
-static void appendConsoleLog(const std::string& msg)
-{
-        std::lock_guard<std::mutex> lock(g_consoleMutex);
-        g_consoleLog.push_back(msg);
-        g_scrollConsole = true;
-}
+
 
 static const ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoBringToFrontOnFocus | 
 											ImGuiWindowFlags_NoCollapse | 
@@ -2815,17 +2828,21 @@ void RenderAssetViewWindow() {
 
 void RenderConsoleWindow()
 {
-        ImGui::Begin("Console", nullptr, windowFlags);
+        ImGui::Begin("Console", nullptr, ImGuiWindowFlags_NoBringToFrontOnFocus |
+											ImGuiWindowFlags_NoCollapse |
+											ImGuiWindowFlags_NoFocusOnAppearing |
+											ImGuiWindowFlags_NoTitleBar |
+											ImGuiWindowFlags_NoMove);
 
         std::lock_guard<std::mutex> lock(g_consoleMutex);
         for (const auto& line : g_consoleLog)
         {
-                ImGui::TextUnformatted(line.c_str());
+            ImGui::TextUnformatted(line.c_str());
         }
         if (g_scrollConsole)
         {
-                ImGui::SetScrollHereY(1.0f);
-                g_scrollConsole = false;
+            ImGui::SetScrollHereY(1.0f);
+            g_scrollConsole = false;
         }
 
         ImGui::End();
@@ -3014,11 +3031,11 @@ class GUI_Helper : public GuiMenu {
 		RenderViewWindow();
 		RenderSceneHierarchyWindow();
 		RenderInspectorWindow();
-                RenderAssetViewWindow();
-                RenderConsoleWindow();
-                ShowTextureCreatorWindow();
-                ShowShaderCreatorWindow();
-                ShowTextureDisplayWindow();
+        RenderAssetViewWindow();
+        RenderConsoleWindow();
+        ShowTextureCreatorWindow();
+        ShowShaderCreatorWindow();
+        ShowTextureDisplayWindow();
 
 		DisplayDebugInfoWindow();
 		
@@ -3097,7 +3114,6 @@ static bool debugTerrainFlag = false;
 class EditorApp : public Application
 {
 public:
-
 	void start() override
 	{
 
@@ -3105,13 +3121,11 @@ public:
 		
 		ImGui::SetCurrentContext((ImGuiContext * )Engine::get()->getImguiHandler()->getCurrentContext());
 
-                setStyleAndColors();
+        setStyleAndColors();
 
-                NativeScriptsLoader::instance->init();
+        NativeScriptsLoader::instance->init();
 
-                Logger::setCallback(appendConsoleLog);
-
-                Engine::get()->getEventSystem()->pushLayer(uiLayer);
+        Engine::get()->getEventSystem()->pushLayer(uiLayer);
 
 		uiHandler = Engine::get()->getEventSystem()->bindToLayer(uiLayer->name);
 		gameHandler = Engine::get()->getEventSystem()->bindToLayer("GameLayer");

--- a/EditorApp/Editor.cpp
+++ b/EditorApp/Editor.cpp
@@ -17,6 +17,9 @@
 #include "EditorState.h"
 
 #include <imgui_stdlib.h>
+#include "core/Logger.h"
+#include <vector>
+#include <mutex>
 
 #define BEGIN_IMGUI_TABLE(name) \
 	if (ImGui::BeginTable(name, 2, ImGuiTableFlags_None)) { \
@@ -56,8 +59,20 @@ static bool showShaderCreateWindow = false;
 
 static bool startButtonPressed = false;
 
+// Console log storage
+static std::vector<std::string> g_consoleLog;
+static std::mutex g_consoleMutex;
+static bool g_scrollConsole = false;
+
 static std::string selectedTextureName;
 static bool showTextureDisplayWindow = false;
+
+static void appendConsoleLog(const std::string& msg)
+{
+        std::lock_guard<std::mutex> lock(g_consoleMutex);
+        g_consoleLog.push_back(msg);
+        g_scrollConsole = true;
+}
 
 static const ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoBringToFrontOnFocus | 
 											ImGuiWindowFlags_NoCollapse | 
@@ -2798,6 +2813,24 @@ void RenderAssetViewWindow() {
 	ImGui::EndChild(); // end scrollable region
 }
 
+void RenderConsoleWindow()
+{
+        ImGui::Begin("Console", nullptr, windowFlags);
+
+        std::lock_guard<std::mutex> lock(g_consoleMutex);
+        for (const auto& line : g_consoleLog)
+        {
+                ImGui::TextUnformatted(line.c_str());
+        }
+        if (g_scrollConsole)
+        {
+                ImGui::SetScrollHereY(1.0f);
+                g_scrollConsole = false;
+        }
+
+        ImGui::End();
+}
+
 void DisplayDebugInfoWindow()
 {
 	//if (displayDebugInfoWindow)
@@ -2969,21 +3002,23 @@ class GUI_Helper : public GuiMenu {
 
 			ImGui::DockBuilderDockWindow("Scene Hierarchy", dock_id_left);
 			ImGui::DockBuilderDockWindow("Inspector", dock_id_right);
-			ImGui::DockBuilderDockWindow("Asset View", dock_id_bottom);
-			ImGui::DockBuilderDockWindow("Simulation Controls", dock_id_top);
-			ImGui::DockBuilderDockWindow("View", dockspace_id);
-			ImGui::DockBuilderFinish(dockspace_id);
-		}
+                        ImGui::DockBuilderDockWindow("Asset View", dock_id_bottom);
+                        ImGui::DockBuilderDockWindow("Console", dock_id_bottom);
+                        ImGui::DockBuilderDockWindow("Simulation Controls", dock_id_top);
+                        ImGui::DockBuilderDockWindow("View", dockspace_id);
+                        ImGui::DockBuilderFinish(dockspace_id);
+                }
 
 		// Render UI
 		RenderSimulationControlView();
 		RenderViewWindow();
 		RenderSceneHierarchyWindow();
 		RenderInspectorWindow();
-		RenderAssetViewWindow();
-		ShowTextureCreatorWindow();
-		ShowShaderCreatorWindow();
-		ShowTextureDisplayWindow();
+                RenderAssetViewWindow();
+                RenderConsoleWindow();
+                ShowTextureCreatorWindow();
+                ShowShaderCreatorWindow();
+                ShowTextureDisplayWindow();
 
 		DisplayDebugInfoWindow();
 		
@@ -3070,11 +3105,13 @@ public:
 		
 		ImGui::SetCurrentContext((ImGuiContext * )Engine::get()->getImguiHandler()->getCurrentContext());
 
-		setStyleAndColors();
+                setStyleAndColors();
 
-		NativeScriptsLoader::instance->init();
+                NativeScriptsLoader::instance->init();
 
-		Engine::get()->getEventSystem()->pushLayer(uiLayer);
+                Logger::setCallback(appendConsoleLog);
+
+                Engine::get()->getEventSystem()->pushLayer(uiLayer);
 
 		uiHandler = Engine::get()->getEventSystem()->bindToLayer(uiLayer->name);
 		gameHandler = Engine::get()->getEventSystem()->bindToLayer("GameLayer");

--- a/Engine/src/core/Logger.cpp
+++ b/Engine/src/core/Logger.cpp
@@ -1,3 +1,57 @@
 #include "core/Logger.h"
+#include <spdlog/sinks/base_sink.h>
+#include <mutex>
 
 std::shared_ptr<spdlog::logger> Logger::s_logger;
+std::function<void(const std::string&)> Logger::s_callback;
+
+// Custom sink that forwards log messages to the registered callback
+class CallbackSink_mt : public spdlog::sinks::base_sink<std::mutex>
+{
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override
+    {
+        spdlog::memory_buf_t formatted;
+        this->formatter_->format(msg, formatted);
+        Logger::invokeCallback(std::string(formatted.begin(), formatted.end()));
+    }
+
+    void flush_() override {}
+};
+
+void Logger::init(const std::string& filePath)
+{
+    std::vector<spdlog::sink_ptr> sinks;
+
+    auto consoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    consoleSink->set_pattern("[%T] [%^%l%$] %v");
+    sinks.push_back(consoleSink);
+
+    if (!filePath.empty())
+    {
+        auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filePath, true);
+        fileSink->set_pattern("[%Y-%m-%d %T] [%l] %v");
+        sinks.push_back(fileSink);
+    }
+
+    // Sink to forward messages to callback
+    sinks.push_back(std::make_shared<CallbackSink_mt>());
+
+    s_logger = std::make_shared<spdlog::logger>("Engine", sinks.begin(), sinks.end());
+    s_logger->set_level(spdlog::level::trace);
+    spdlog::register_logger(s_logger);
+}
+
+void Logger::setCallback(std::function<void(const std::string&)> cb)
+{
+    s_callback = std::move(cb);
+}
+
+void Logger::invokeCallback(const std::string& msg)
+{
+    if (s_callback)
+    {
+        s_callback(msg);
+    }
+}
+

--- a/Engine/src/core/Logger.cpp
+++ b/Engine/src/core/Logger.cpp
@@ -8,6 +8,11 @@ std::function<void(const std::string&)> Logger::s_callback;
 // Custom sink that forwards log messages to the registered callback
 class CallbackSink_mt : public spdlog::sinks::base_sink<std::mutex>
 {
+public:
+    CallbackSink_mt()
+    {
+        set_pattern("[%T] [%^%l%$] %v");
+    }
 protected:
     void sink_it_(const spdlog::details::log_msg& msg) override
     {
@@ -30,7 +35,7 @@ void Logger::init(const std::string& filePath)
     if (!filePath.empty())
     {
         auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filePath, true);
-        fileSink->set_pattern("[%Y-%m-%d %T] [%l] %v");
+        fileSink->set_pattern("[%T] [%^%l%$] %v");
         sinks.push_back(fileSink);
     }
 

--- a/Engine/src/core/Logger.h
+++ b/Engine/src/core/Logger.h
@@ -5,43 +5,36 @@
 #pragma once
 #include <memory>
 #include <string>
+#include <functional>
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/sinks/basic_file_sink.h>
 
 #include "core/Core.h"
 
+class CallbackSink_mt; // Forward declaration
+
 class EngineAPI Logger
 {
 public:
     // Initializes logger. If filePath is empty, logs to console only.
-    static void init(const std::string& filePath = "")
-    {
-        std::vector<spdlog::sink_ptr> sinks;
-
-        auto consoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-        consoleSink->set_pattern("[%T] [%^%l%$] %v");
-        sinks.push_back(consoleSink);
-
-        if (!filePath.empty())
-        {
-            auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filePath, true);
-            fileSink->set_pattern("[%Y-%m-%d %T] [%l] %v");
-            sinks.push_back(fileSink);
-        }
-
-        s_logger = std::make_shared<spdlog::logger>("Engine", sinks.begin(), sinks.end());
-        s_logger->set_level(spdlog::level::trace);
-        spdlog::register_logger(s_logger);
-    }
+    static void init(const std::string& filePath = "");
 
     static std::shared_ptr<spdlog::logger>& get()
     {
         return s_logger;
     }
 
+    // Register a callback invoked for each log message
+    static void setCallback(std::function<void(const std::string&)> cb);
+
 private:
+    static void invokeCallback(const std::string& msg);
+
     static std::shared_ptr<spdlog::logger> s_logger;
+    static std::function<void(const std::string&)> s_callback;
+
+    friend class CallbackSink_mt;
 };
 
 // Macros


### PR DESCRIPTION
## Summary
- Add log callback support to engine logger
- Show log output in new Console window within the editor
- Dock Console alongside Asset View for easy access

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: cc error '/MT: linker input file not found')*


------
https://chatgpt.com/codex/tasks/task_e_68a38cdf8b34832a952b0d4a6adb510d