### PR TITLE
Add shadow sampling to terrain shader

### DIFF
--- a/Engine/Resources/Engine/Shaders/TerrainShader.glsl
+++ b/Engine/Resources/Engine/Shaders/TerrainShader.glsl
@@ -153,6 +153,7 @@ void main()
 #include ../../../../Engine/Resources/Engine/Shaders/include/uniforms.glsl
 #include ../../../../Engine/Resources/Engine/Shaders/include/functions.glsl
 #include ../../../../Engine/Resources/Engine/Shaders/include/PBR.glsl
+#include ../../../../Engine/Resources/Engine/Shaders/include/Shadows.glsl
 
 uniform int textureCount;
 
@@ -170,6 +171,7 @@ uniform vec3 cameraPos;
 uniform samplerCube gIrradianceMap;
 uniform samplerCube gPrefilterEnvMap;
 uniform sampler2D gBRDFIntegrationLUT;
+uniform sampler2D gShadowMap;
 
 #pragma editable
 uniform PBR_Sampler samplerAlbedo;
@@ -238,18 +240,21 @@ void main()
     float metallic = metallicFactor;
     float roughness = roughnessFactor;
 
+    vec4 fragPosInLightSpace = lightSpaceMatrix * vec4(fragPos, 1.f);
+    float shadow = calculateShadows(fragPosInLightSpace, gShadowMap);
+
     vec3 color = calculatePBR(
-		albedo, 
-		normal, 
-		metallic, 
-		roughness, 
-		1.f, 
-		cameraPos, 
-		fragPos,
-		1.f,
-		gPrefilterEnvMap, 
-		gIrradianceMap, 
-		gBRDFIntegrationLUT);
+                albedo,
+                normal,
+                metallic,
+                roughness,
+                1.f,
+                cameraPos,
+                fragPos,
+                shadow,
+                gPrefilterEnvMap,
+                gIrradianceMap,
+                gBRDFIntegrationLUT);
 
     // HDR tonemapping
     color = color / (color + vec3(1.0));

--- a/Engine/src/runtime/Scene.cpp
+++ b/Engine/src/runtime/Scene.cpp
@@ -436,7 +436,7 @@ void Scene::draw(float deltaTime)
 				m_terrainShader->setTextureInShader(graphics->irradianceMap, "gIrradianceMap", 5);
 				m_terrainShader->setTextureInShader(graphics->prefilterEnvMap, "gPrefilterEnvMap", 6);
 				m_terrainShader->setTextureInShader(graphics->brdfLUT, "gBRDFIntegrationLUT", 7);
-				m_terrainShader->setTextureInShader(graphics->shadowMap, "shadowMap", 8);
+				m_terrainShader->setTextureInShader(graphics->shadowMap, "gShadowMap", 8);
 				m_terrainShader->setTextureInShader(heightmap, "heightMap", 9);
 
 				terrain.m_material.get()->use();


### PR DESCRIPTION
## Summary
- add shadow map sampling and shadow include to the terrain shader
- feed calculated shadow factor into PBR lighting for terrain fragments

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a0c329a1c832a95c1a7f83c6f90c0)