### PR TITLE
Add animation support to highlight pass

### DIFF
--- a/Engine/Resources/Engine/Shaders/HighlighMaskShader.glsl
+++ b/Engine/Resources/Engine/Shaders/HighlighMaskShader.glsl
@@ -9,12 +9,27 @@
 #include ../../../../Engine/Resources/Engine/Shaders/include/uniforms.glsl
 #include ../../../../Engine/Resources/Engine/Shaders/include/functions.glsl
                                                                                     
-layout (location = 0) in vec3 aPos;                                              
-                                                                                    
-void main()                                                                         
-{  
-    gl_Position = projection * view * model * vec4(aPos, 1.0); 
-                                  
+layout (location = 0) in vec3 aPos;
+layout (location = 5) in ivec3 boneIDs;
+layout (location = 6) in vec3 boneWeights;
+layout (location = 7) in mat4 instanceModel;
+
+#include ../../../../Engine/Resources/Engine/Shaders/include/animation.glsl
+
+void main()
+{
+    mat4 aModel = model;
+
+    if (isGpuInstanced)
+    {
+        aModel = model * instanceModel;
+    }
+
+    vec4 totalPosition;
+    applySkinningPosition(aPos, boneIDs, boneWeights, totalPosition);
+
+    gl_Position = projection * view * aModel * totalPosition;
+
 }
 
 #frag

--- a/Engine/Resources/Engine/Shaders/PBRShader.glsl
+++ b/Engine/Resources/Engine/Shaders/PBRShader.glsl
@@ -15,9 +15,7 @@ layout (location = 7) in mat4 instanceModel;
 #include ../../../../Engine/Resources/Engine/Shaders/include/structs.glsl
 #include ../../../../Engine/Resources/Engine/Shaders/include/uniforms.glsl
 #include ../../../../Engine/Resources/Engine/Shaders/include/functions.glsl
-
-const int MAX_BONES = 100;
-const int MAX_BONE_INFLUENCE = 3;
+#include ../../../../Engine/Resources/Engine/Shaders/include/animation.glsl
 
 // ----- Out ----- //
 
@@ -27,9 +25,6 @@ out VS_OUT {
     vec2 texCoord;
 } vs_out;
 
-// ----- Uniforms ----- //
-
-uniform mat4 finalBonesMatrices[MAX_BONES];
 uniform mat3 transposeInverseModelMatrix;
 
 float getTime()
@@ -50,30 +45,9 @@ void main()
         aModel = model * instanceModel;
     }
 
-    vec4 totalPosition = vec4(pos, 1.0f);
-    vec3 totalNormal = norm;
-
-    if (isAnimated)
-    {
-        totalPosition = vec4(0.0f);
-        totalNormal = vec3(0.0f);
-
-        for (int i = 0; i < MAX_BONE_INFLUENCE; i++)
-        {
-            if (boneIDs[i] == -1) continue;
-            if (boneIDs[i] >= MAX_BONES)
-            {
-                totalPosition = vec4(pos, 1.0f);
-                totalNormal = norm;
-                break;
-            }
-
-            vec4 localPosition = finalBonesMatrices[boneIDs[i]] * vec4(pos, 1.0f);
-            totalPosition += localPosition * boneWeights[i];
-            vec3 localNormal = mat3(finalBonesMatrices[boneIDs[i]]) * norm;
-            totalNormal += localNormal * boneWeights[i];
-        }
-    }
+    vec4 totalPosition;
+    vec3 totalNormal;
+    applySkinning(pos, norm, boneIDs, boneWeights, totalPosition, totalNormal);
 
     vec3 aNorm = transposeInverseModelMatrix * totalNormal;
 

--- a/Engine/Resources/Engine/Shaders/PBR_GeomPassShader.glsl
+++ b/Engine/Resources/Engine/Shaders/PBR_GeomPassShader.glsl
@@ -16,9 +16,7 @@ layout (location = 7) in mat4 instanceModel;
 #include ../../../../Engine/Resources/Engine/Shaders/include/structs.glsl
 #include ../../../../Engine/Resources/Engine/Shaders/include/uniforms.glsl
 #include ../../../../Engine/Resources/Engine/Shaders/include/functions.glsl
-
-const int MAX_BONES = 100;
-const int MAX_BONE_INFLUENCE = 3;
+#include ../../../../Engine/Resources/Engine/Shaders/include/animation.glsl
 
 // ----- Structs ----- //
 
@@ -31,10 +29,6 @@ out VS_OUT {
     vec3 fragPosVS;
 	vec3 normalVS;
 } vs_out;
-
-// ----- Uniforms ----- //
-
-uniform mat4 finalBonesMatrices[MAX_BONES];
 
 // ----- Forward Declerations ----- //
 
@@ -58,31 +52,9 @@ void main()
 		aModel = model * instanceModel;
 	}
 
-	vec4 totalPosition = vec4(pos, 1.0f);
-	vec3 totalNormal = norm;
-	
-	if(isAnimated)
-	{
-		totalPosition = vec4(0.0f);
-		totalNormal = vec3(0.0f);
-
-		for(int i = 0 ; i < MAX_BONE_INFLUENCE ; i++)
-		{
-			if(boneIDs[i] == -1) 
-				continue;
-			if(boneIDs[i] >=MAX_BONES) 
-			{
-				totalPosition = vec4(pos,1.0f);
-				totalNormal = norm;
-				break;
-			}
-
-			vec4 localPosition = finalBonesMatrices[boneIDs[i]] * vec4(pos,1.0f);
-			totalPosition += localPosition * boneWeights[i];
-			vec3 localNormal = mat3(finalBonesMatrices[boneIDs[i]]) * norm;
-			totalNormal += localNormal * boneWeights[i];
-		}
-	}
+        vec4 totalPosition;
+        vec3 totalNormal;
+        applySkinning(pos, norm, boneIDs, boneWeights, totalPosition, totalNormal);
 
 	vec3 aNorm = mat3(transpose(inverse(aModel))) * totalNormal;
 #ifdef CUSTOM_SHADER

--- a/Engine/Resources/Engine/Shaders/SimpleDepthShader.glsl
+++ b/Engine/Resources/Engine/Shaders/SimpleDepthShader.glsl
@@ -6,40 +6,19 @@ layout (location = 0) in vec3 pos;
 layout (location = 5) in ivec3 boneIDs;
 layout (location = 6) in vec3 boneWeights;
 
-const int MAX_BONES = 100;
-const int MAX_BONE_INFLUENCE = 3;
-
-uniform mat4 lightSpaceMatrix;
-uniform mat4 model;
-uniform bool isAnimated;
-
-uniform mat4 finalBonesMatrices[MAX_BONES];
+#include ../../../../Engine/Resources/Engine/Shaders/include/defines.glsl
+#include ../../../../Engine/Resources/Engine/Shaders/include/structs.glsl
+#include ../../../../Engine/Resources/Engine/Shaders/include/uniforms.glsl
+#include ../../../../Engine/Resources/Engine/Shaders/include/functions.glsl
+#include ../../../../Engine/Resources/Engine/Shaders/include/animation.glsl
 
 void main()
 {
-    vec4 totalPosition = vec4(pos, 1.0f);
-
-    if(isAnimated)
-	{
-		totalPosition = vec4(0.0f);
-
-		for(int i = 0 ; i < MAX_BONE_INFLUENCE ; i++)
-		{
-			if(boneIDs[i] == -1) 
-				continue;
-			if(boneIDs[i] >=MAX_BONES) 
-			{
-				totalPosition = vec4(pos,1.0f);
-				break;
-			}
-
-			vec4 localPosition = finalBonesMatrices[boneIDs[i]] * vec4(pos,1.0f);
-			totalPosition += localPosition * boneWeights[i];
-		}
-	}
+    vec4 totalPosition;
+    applySkinningPosition(pos, boneIDs, boneWeights, totalPosition);
 
     gl_Position = lightSpaceMatrix * model * totalPosition;
-}  
+}
 
 #frag
 

--- a/Engine/Resources/Engine/Shaders/include/animation.glsl
+++ b/Engine/Resources/Engine/Shaders/include/animation.glsl
@@ -1,0 +1,38 @@
+const int MAX_BONES = 100;
+const int MAX_BONE_INFLUENCE = 3;
+
+uniform mat4 finalBonesMatrices[MAX_BONES];
+
+void applySkinning(vec3 pos, vec3 norm, ivec3 boneIDs, vec3 boneWeights, out vec4 totalPosition, out vec3 totalNormal)
+{
+    totalPosition = vec4(pos, 1.0f);
+    totalNormal = norm;
+
+    if (isAnimated)
+    {
+        totalPosition = vec4(0.0f);
+        totalNormal = vec3(0.0f);
+
+        for (int i = 0; i < MAX_BONE_INFLUENCE; i++)
+        {
+            if (boneIDs[i] == -1) continue;
+            if (boneIDs[i] >= MAX_BONES)
+            {
+                totalPosition = vec4(pos, 1.0f);
+                totalNormal = norm;
+                break;
+            }
+
+            vec4 localPosition = finalBonesMatrices[boneIDs[i]] * vec4(pos, 1.0f);
+            totalPosition += localPosition * boneWeights[i];
+            vec3 localNormal = mat3(finalBonesMatrices[boneIDs[i]]) * norm;
+            totalNormal += localNormal * boneWeights[i];
+        }
+    }
+}
+
+void applySkinningPosition(vec3 pos, ivec3 boneIDs, vec3 boneWeights, out vec4 totalPosition)
+{
+    vec3 unusedNormal;
+    applySkinning(pos, vec3(0.0f), boneIDs, boneWeights, totalPosition, unusedNormal);
+}

--- a/Engine/src/runtime/Scene.cpp
+++ b/Engine/src/runtime/Scene.cpp
@@ -614,15 +614,34 @@ void Scene::draw(float deltaTime)
 						// 1st pass
 						m_highlightRenderView->bind();
 						RenderCommand::clear();
-						m_highlightMaskShader->use();
-						
-						m_highlightMaskShader->setViewMatrix(graphics->view);
-						m_highlightMaskShader->setProjectionMatrix(graphics->projection);
+                                                m_highlightMaskShader->use();
 
-						for (auto& m : mesh->getMeshes())
-						{
-							m_highlightMaskShader->setModelMatrix(e.getComponent<Transformation>().getWorldTransformation() * m->getRestTransform());
-							RenderCommand::draw(m->getVAO());
+                                                m_highlightMaskShader->setViewMatrix(graphics->view);
+                                                m_highlightMaskShader->setProjectionMatrix(graphics->projection);
+
+                                                m_highlightMaskShader->setUniformValue("isGpuInstanced", false);
+
+                                                auto animator = e.tryGetComponent<Animator>();
+                                                if (!animator || animator->m_currentAnimation.isEmpty())
+                                                {
+                                                        m_highlightMaskShader->setUniformValue("isAnimated", false);
+                                                }
+                                                else
+                                                {
+                                                        std::vector<glm::mat4> finalBoneMatrices;
+                                                        animator->getFinalBoneMatrices(mesh.get(), finalBoneMatrices);
+                                                        for (int i = 0; i < finalBoneMatrices.size(); ++i)
+                                                        {
+                                                                m_highlightMaskShader->setUniformValue("finalBonesMatrices[" + std::to_string(i) + "]", finalBoneMatrices[i]);
+                                                        }
+
+                                                        m_highlightMaskShader->setUniformValue("isAnimated", true);
+                                                }
+
+                                                for (auto& m : mesh->getMeshes())
+                                                {
+                                                        m_highlightMaskShader->setModelMatrix(e.getComponent<Transformation>().getWorldTransformation() * m->getRestTransform());
+                                                        RenderCommand::draw(m->getVAO());
 						}
 
 						glPopDebugGroup();


### PR DESCRIPTION
## Summary
- add shared animation include for skinning calculations
- update shaders to reuse the animation helper and support skinned highlight rendering
- set animation uniforms in the highlight mask pass so animated meshes highlight correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a0cd9d898832a8856eaf412de91eb)